### PR TITLE
New benchmark data schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ There is a special `cache/index.json` file that maps json file names to their ti
 The `Benchmarks Upload` actions the runs [website_regen.py](https://github.com/enso-org/enso/blob/develop/tools/performance/engine-benchmarks/website_regen.py) script.
 
 ## Contributing
+When cloning the repo, it is recommended to truncate the history to save time:
+```bash
+git clone --depth 1
+```
+(because this repo contains some big HTML files).
 Run the dev server with `npm install && npx vite`.
 
 

--- a/schema/cache-v2.json
+++ b/schema/cache-v2.json
@@ -50,7 +50,7 @@
         "jdkVersion"
       ]
     },
-    "gh_action_run": {
+    "ghActionRun": {
       "type": ["object", "null"],
       "description": "Details about the benchmark GitHub Action run. On local run, can be null. If run on the CI, must not be null.",
       "properties": {
@@ -250,7 +250,7 @@
   "required": [
     "$schema",
     "configuration",
-    "gh_action_run",
+    "ghActionRun",
     "results"
   ]
 }

--- a/schema/cache-v2.json
+++ b/schema/cache-v2.json
@@ -1,13 +1,58 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$comment": "Version 2.0",
-  "title": "BenchRun",
-  "description": "Data from the benchmarking GitHub action",
+  "title": "Benchmark results",
+  "description": "Aggregated data from all the JMH benchmark runs",
   "type": "object",
   "properties": {
-    "bench_run": {
+    "$schema": {
+      "type": "string",
+      "description": "Schema specification URI",
+      "format": "uri"
+    },
+    "configuration": {
       "type": "object",
-      "description": "Details about the benchmark GitHub Action run",
+      "description": "Benchmark configuration - HW, OS, JVM, etc.",
+      "properties": {
+        "osName": {
+          "type": "string",
+          "description": "Operating system name, as reported by the `os.name` system property"
+        },
+        "osArch": {
+          "type": "string",
+          "description": "Operating system architecture, as reported by the `os.arch` system property"
+        },
+        "osVersion": {
+          "type": "string"
+        },
+        "vmName": {
+          "type": "string",
+          "description": "`java.vm.name` system property"
+        },
+        "vmVersion": {
+          "type": "string",
+          "description": "`java.vm.version` system property"
+        },
+        "vmVendor": {
+          "type": "string",
+          "description": "`java.vm.vendor` system property"
+        },
+        "jdkVersion": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "osName",
+        "osArch",
+        "vmName",
+        "vmVersion",
+        "vmVendor",
+        "jdkVersion"
+      ]
+    },
+    "gh_action_run": {
+      "type": ["object", "null"],
+      "description": "Details about the benchmark GitHub Action run. On local run, can be null. If run on the CI, must not be null.",
       "properties": {
         "id": {
           "type": "string",
@@ -79,99 +124,133 @@
     },
     "results": {
       "type": "array",
-      "items": true,
-      "description": "The benchmark results",
-      "properties": {
-        "label": {
-          "type": "string"
-        },
-        "score": {
-          "type": "number",
-          "description": "Average number of iterations per millisecond"
-        },
-        "min": {
-          "type": "number"
-        },
-        "max": {
-          "type": "number"
-        },
-        "mean": {
-          "type": "number"
-        },
-        "stddev": {
-          "type": "number"
-        },
-        "samples": {
-          "type": "number",
-          "description": "The number of measurement samples (iterations) taken"
-        },
-        "configuration": {
-          "type": "object",
-          "properties": {
-            "osName": {
-              "type": "string"
-            },
-            "osArch": {
-              "type": "string"
-            },
-            "osVersion": {
-              "type": "string"
-            },
-            "jdkVersion": {
-              "type": "string"
-            },
-            "vmName": {
-              "type": "string",
-              "description": "`java.vm.name` system property"
-            },
-            "vmVersion": {
-              "type": "string",
-              "description": "`java.vm.version` system property"
-            },
-            "vmVendor": {
-              "type": "string",
-              "description": "`java.vm.vendor` system property"
-            },
-            "warmupIterations": {
-              "type": "integer",
-              "description": "The number of warmup iterations"
-            },
-            "warmupMillis": {
-              "type": "integer",
-              "description": "The number of milliseconds per warmup iteration"
-            },
-            "measureMillis": {
-              "type": "integer",
-              "description": "The number of milliseconds per measurement iteration"
-            }
+      "description": "List of benchmark results",
+      "items": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Benchmark label - name of the benchmark"
           },
-          "required": [
-            "osName",
-            "osArch",
-            "osVersion",
-            "jdkVersion",
-            "vmName",
-            "vmVersion",
-            "vmVendor",
-            "warmupIterations",
-            "warmupMillis",
-            "measureMillis"
-          ]
-        }
-      },
-      "required": [
-        "label",
-        "score",
-        "min",
-        "max",
-        "mean",
-        "stddev",
-        "samples"
-      ]
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "score": {
+            "type": "number",
+            "description": "Benchmark score - Average operation time, i.e., how many milliseconds it takes for a single iteration. Lower is better."
+          },
+          "samples": {
+            "type": "number",
+            "description": "Number of measurement iterations (samples taken)"
+          },
+          "warmupIterations": {
+            "type": "integer",
+            "description": "The number of warmup iterations"
+          },
+          "warmupMillis": {
+            "type": "integer",
+            "description": "The number of milliseconds per warmup iteration"
+          },
+          "measureIterations": {
+            "type": "integer",
+            "description": "The number of measurement iterations. Usually is the same as number of samples."
+          },
+          "measureMillis": {
+            "type": "integer",
+            "description": "The number of milliseconds per measurement iteration"
+          },
+          "commitId": {
+            "type": "string"
+          },
+          "branch": {
+            "type": "string",
+            "description": "Branch name (the current Git reference)"
+          },
+          "measurementStatistics": {
+            "type": "object",
+            "description": "Measurement statistics from the JMH's primary result",
+            "properties": {
+              "stddev": {
+                "type": ["number", "string"],
+                "description": "Standard deviation of the primary result",
+                "enum": ["NaN"]
+              },
+              "mean": {
+                "type": "number",
+                "description": "Mean of the primary result"
+              },
+              "min": {
+                "type": "number",
+                "description": "Minimum value of the primary result"
+              },
+              "max": {
+                "type": "number",
+                "description": "Maximum value of the primary result"
+              },
+              "error50": {
+                "type": ["number", "string"],
+                "description": "Error margin at 50% confidence level",
+                "enum": ["NaN"]
+              },
+              "error95": {
+                "type": ["number", "string"],
+                "description": "Error margin at 95% confidence level",
+                "enum": ["NaN"]
+              },
+              "percentiles": {
+                "type": "array",
+                "description": "Percentile values",
+                "uniqueItems": true,
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "number",
+                      "description": "Percentile value"
+                    },
+                    "percentile": {
+                      "type": "number",
+                      "description": "Percentile"
+                    }
+                  }
+                },
+                "required": [
+                  "value",
+                  "percentile"
+                ]
+              }
+            },
+            "required": [
+              "stddev",
+              "mean",
+              "min",
+              "max",
+              "error50",
+              "error95",
+              "percentiles"
+            ]
+          }
+        },
+        "required": [
+          "label",
+          "timestamp",
+          "score",
+          "samples",
+          "warmupIterations",
+          "warmupMillis",
+          "measureMillis",
+          "commitId",
+          "branch",
+          "measurementStatistics"
+        ]
+      }
     }
   },
   "required": [
-    "bench_run",
+    "$schema",
+    "configuration",
+    "gh_action_run",
     "results"
   ]
 }


### PR DESCRIPTION
Benchmark data schema version 2.0.

The updated [schema/cache-v2.json](https://github.com/enso-org/engine-benchmark-results/blob/2b29af9dee5d4caea75a67fe2b1ef721dc09aaad/schema/cache-v2.json) should be used in all the repos that produce or consume the benchmark results.